### PR TITLE
Apply redux & redux-saga for authentication, HOC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,11 +37,15 @@
         "react-router-dom": "6.2.1",
         "react-scripts": "5.0.0",
         "redux": "4.1.2",
+        "redux-logger": "3.0.6",
+        "redux-persist": "6.0.0",
+        "redux-saga": "1.1.3",
         "typescript": "4.1.6"
       },
       "devDependencies": {
         "@babel/preset-react": "7.16.7",
         "@emotion/babel-plugin": "11.7.2",
+        "@types/redux-logger": "3.0.9",
         "webpack": "5.65.0"
       }
     },
@@ -3202,6 +3206,53 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "node_modules/@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "node_modules/@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "node_modules/@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "node_modules/@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "node_modules/@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.1.tgz",
@@ -4204,6 +4255,15 @@
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/redux-logger": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
+      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
+      "dev": true,
+      "dependencies": {
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -7120,6 +7180,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "node_modules/deep-equal": {
       "version": "1.1.1",
@@ -14528,6 +14593,30 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
+    "node_modules/redux-saga": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "dependencies": {
+        "@redux-saga/core": "^1.1.3"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -16124,6 +16213,27 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "dependencies": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "node_modules/typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "node_modules/typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "dependencies": {
+        "typescript-compare": "^0.0.2"
       }
     },
     "node_modules/unbox-primitive": {
@@ -19245,6 +19355,53 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
+    "@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
     "@reduxjs/toolkit": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.1.tgz",
@@ -20029,6 +20186,15 @@
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/redux-logger": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
+      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
+      "dev": true,
+      "requires": {
+        "redux": "^4.0.0"
       }
     },
     "@types/resolve": {
@@ -22174,6 +22340,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -27462,6 +27633,28 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
+    },
+    "redux-saga": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "requires": {
+        "@redux-saga/core": "^1.1.3"
+      }
+    },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -28668,6 +28861,27 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
       "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow=="
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "react-router-dom": "6.2.1",
     "react-scripts": "5.0.0",
     "redux": "4.1.2",
+    "redux-logger": "3.0.6",
+    "redux-persist": "6.0.0",
+    "redux-saga": "1.1.3",
     "typescript": "4.1.6"
   },
   "scripts": {
@@ -68,6 +71,7 @@
   "devDependencies": {
     "@babel/preset-react": "7.16.7",
     "@emotion/babel-plugin": "11.7.2",
+    "@types/redux-logger": "3.0.9",
     "webpack": "5.65.0"
   }
 }

--- a/src/api/auth.tsx
+++ b/src/api/auth.tsx
@@ -24,8 +24,8 @@ export const onLogin = async ({ email, pw }: LoginInputData) => {
     const { accessToken } = response.data;
     axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
     return response;
-  } catch (e) {
-    return e;
+  } catch (e: any) {
+    return e.response;
   }
 };
 

--- a/src/api/auth.tsx
+++ b/src/api/auth.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { LoginInputData } from "types/authType";
 
 export const onRegister = (
   email: string,
@@ -16,17 +17,15 @@ export const onRegister = (
     });
 };
 
-export const onLogin = (email: string, pw: string) => {
-  axios
-    .post("/api/user/login", { email, pw })
-    .then((res) => {
-      console.log(res.data.token);
-      const { accessToken } = res.data.token;
-      axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
-    })
-    .catch((e) => {
-      console.log(e);
-    });
+export const onLogin = async ({ email, pw }: LoginInputData) => {
+  try {
+    const response = await axios.post("/api/user/login", { email, pw });
+    const { accessToken } = response.data.token;
+    axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+    return response.status;
+  } catch (e) {
+    return e;
+  }
 };
 
 export const onLogout = () => {};

--- a/src/api/auth.tsx
+++ b/src/api/auth.tsx
@@ -20,9 +20,10 @@ export const onRegister = (
 export const onLogin = async ({ email, pw }: LoginInputData) => {
   try {
     const response = await axios.post("/api/user/login", { email, pw });
-    const { accessToken } = response.data.token;
+    console.log(response);
+    const { accessToken } = response.data;
     axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
-    return response.status;
+    return response;
   } catch (e) {
     return e;
   }

--- a/src/components/AuthHoc.tsx
+++ b/src/components/AuthHoc.tsx
@@ -1,0 +1,27 @@
+import { useAppSelector } from "hooks/redux-hooks";
+import { FunctionComponent, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+function AuthHoc(
+  SpecificComponent: FunctionComponent,
+  option: boolean,
+  adminRoute = null
+) {
+  function AuthenticationCheck() {
+    const isLoggedIn = useAppSelector((state) => state.userReducer.isLoggedIn);
+    const navigation = useNavigate();
+
+    useEffect(() => {
+      if (!isLoggedIn && option) {
+        navigation("/login");
+      } else if (isLoggedIn && !option) {
+        navigation("/");
+      }
+    }, [isLoggedIn, navigation]);
+
+    return <SpecificComponent />;
+  }
+  return <AuthenticationCheck />;
+}
+
+export default AuthHoc;

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -1,21 +1,25 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import GlobalStyle from "components/app/GlobalStyle";
-import Home from "pages/Home";
-import Login from "pages/Login";
-import Manage from "pages/Manage";
-import Regist from "pages/Regist";
 
 const App = () => {
+  const Home = lazy(() => import("pages/Home"));
+  const Login = lazy(() => import("pages/Login"));
+  const Manage = lazy(() => import("pages/Manage"));
+  const Regist = lazy(() => import("pages/Regist"));
+
   return (
     <>
       <GlobalStyle />
       <Router>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/manage" element={<Manage />} />
-          <Route path="/regist" element={<Regist />} />
-        </Routes>
+        <Suspense fallback={"loading..."}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/manage" element={<Manage />} />
+            <Route path="/regist" element={<Regist />} />
+          </Routes>
+        </Suspense>
       </Router>
     </>
   );

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import GlobalStyle from "components/app/GlobalStyle";
+import Auth from "components/AuthHoc";
 
 const App = () => {
   const Home = lazy(() => import("pages/Home"));
@@ -12,12 +13,12 @@ const App = () => {
     <>
       <GlobalStyle />
       <Router>
-        <Suspense fallback={"loading..."}>
+        <Suspense fallback={<div>loading...</div>}>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/manage" element={<Manage />} />
-            <Route path="/regist" element={<Regist />} />
+            <Route path="/" element={Auth(Home, true)} />
+            <Route path="/manage" element={Auth(Manage, true)} />
+            <Route path="/login" element={Auth(Login, false)} />
+            <Route path="/regist" element={Auth(Regist, false)} />
           </Routes>
         </Suspense>
       </Router>

--- a/src/components/app/rootReducer.tsx
+++ b/src/components/app/rootReducer.tsx
@@ -1,0 +1,8 @@
+import { combineReducers } from "redux";
+import todoReducer from "features/todo/todoSlice";
+import userReducer from "features/user/userSlice";
+
+export default combineReducers({
+  todoReducer,
+  userReducer,
+});

--- a/src/components/app/rootSaga.tsx
+++ b/src/components/app/rootSaga.tsx
@@ -1,0 +1,6 @@
+import { all, fork } from "redux-saga/effects";
+import userSaga from "features/user/userSaga";
+
+export default function* rootSaga() {
+  yield all([fork(userSaga)]);
+}

--- a/src/components/app/store.tsx
+++ b/src/components/app/store.tsx
@@ -1,9 +1,31 @@
 import { configureStore } from "@reduxjs/toolkit";
-import todoSlice from "features/todoSlice";
+import createSagaMiddleware from "@redux-saga/core";
+import { persistReducer } from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import logger from "redux-logger";
+import rootReducer from "./rootReducer";
+import rootSaga from "./rootSaga";
 
-export const store = configureStore({ reducer: { todos: todoSlice } });
+const sagaMiddleware = createSagaMiddleware({});
 
-// 루트 리듀서의 반환값를 유추해줍니다
-// 추후 이 타입을 컨테이너 컴포넌트에서 불러와서 사용해야 하므로 내보내줍니다.
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const initialState = {};
+
+const store = configureStore({
+  reducer: persistedReducer,
+  middleware: [sagaMiddleware, logger],
+  devTools: true,
+  preloadedState: initialState,
+});
+
+sagaMiddleware.run(rootSaga);
+
+export default store;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/components/atoms/TodoItem.tsx
+++ b/src/components/atoms/TodoItem.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { MdDone, MdDelete } from "react-icons/md";
 import { useAppDispatch } from "hooks/redux-hooks";
-import { remove, toggle } from "features/todoSlice";
+import { remove, toggle } from "features/todo/todoSlice";
 
 interface TodoItemProps extends DoneType {
   id: number;

--- a/src/components/molecules/Menus.tsx
+++ b/src/components/molecules/Menus.tsx
@@ -17,12 +17,6 @@ function Menus() {
       <Menu path="/manage" text="MANAGE">
         <ManageIcon />
       </Menu>
-      <Menu path="/account" text="ACCOUNT">
-        <AccountIcon />
-      </Menu>
-      <Menu path="/login" text="LOGIN">
-        <LoginIcon />
-      </Menu>
       <LogoutIcon />
     </MenusWrapper>
   );

--- a/src/components/molecules/Menus.tsx
+++ b/src/components/molecules/Menus.tsx
@@ -1,12 +1,6 @@
 import styled from "@emotion/styled";
 import Menu from "components/atoms/Menu";
-import {
-  AccountIcon,
-  HomeIcon,
-  LoginIcon,
-  LogoutIcon,
-  ManageIcon,
-} from "components/atoms/Icons";
+import { HomeIcon, LogoutIcon, ManageIcon } from "components/atoms/Icons";
 
 function Menus() {
   return (

--- a/src/components/molecules/TodoContent.tsx
+++ b/src/components/molecules/TodoContent.tsx
@@ -3,7 +3,7 @@ import { useAppSelector } from "hooks/redux-hooks";
 import TodoItem from "components/atoms/TodoItem";
 
 function TodoContent() {
-  const todos = useAppSelector((state) => state.todos);
+  const todos = useAppSelector((state) => state.todoReducer);
 
   return (
     <TodoContentWrapper>

--- a/src/components/molecules/TodoCreate.tsx
+++ b/src/components/molecules/TodoCreate.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { ChangeEvent, FormEvent, useState } from "react";
 import { useAppDispatch } from "hooks/redux-hooks";
-import { add } from "features/todoSlice";
+import { add } from "features/todo/todoSlice";
 import Input from "components/atoms/Input";
 
 function TodoCreate() {

--- a/src/features/todo/todoSlice.tsx
+++ b/src/features/todo/todoSlice.tsx
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import type { RootState } from "../components/app/store";
+import type { RootState } from "../../components/app/store";
 
 interface TodoState {
   id: number;

--- a/src/features/user/userSaga.tsx
+++ b/src/features/user/userSaga.tsx
@@ -1,0 +1,26 @@
+import { PayloadAction } from "@reduxjs/toolkit";
+import { AxiosResponse } from "axios";
+import { all, call, fork, put, takeEvery } from "redux-saga/effects";
+import { onLogin } from "api/auth";
+import { userActions } from "./userSlice";
+import { LoginInputData } from "types/authType";
+
+function* authUser(action: PayloadAction<LoginInputData>) {
+  try {
+    const response: AxiosResponse = yield call(onLogin, {
+      ...action.payload,
+    });
+    yield put(userActions.loginSuccess(response));
+  } catch (e: any) {
+    yield put(userActions.loginError(e.response));
+    yield alert("로그인 실패");
+  }
+}
+
+function* watchAuthUser() {
+  yield takeEvery(userActions.login.type, authUser);
+}
+
+export default function* userSaga() {
+  yield all([fork(watchAuthUser)]);
+}

--- a/src/features/user/userSlice.tsx
+++ b/src/features/user/userSlice.tsx
@@ -1,0 +1,55 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export interface UserState {
+  circleName: string;
+  isLoggedIn: boolean;
+  status: number;
+  statusText: string;
+}
+
+const initialState: UserState = {
+  circleName: "",
+  isLoggedIn: false,
+  status: 0,
+  statusText: "loading",
+};
+
+export const userSlice = createSlice({
+  name: "user",
+  initialState,
+  reducers: {
+    // login
+    login: (state, action) => {},
+    loginSuccess: (state, action) => {
+      console.log(action);
+      state.status = action.payload;
+      state.statusText = action.payload?.statusText ?? "Success";
+      state.isLoggedIn = true;
+      // state.circleName = action.payload.circleName;
+    },
+    loginError: (state, action) => {
+      state.status = action.payload ?? 500;
+      state.statusText = action.payload?.statusText ?? "Network Error";
+    },
+
+    // logout
+    logout: (state) => {
+      return {
+        ...state,
+        userData: {},
+        isLoggedIn: false,
+      };
+    },
+    logoutSuccess: (state, action) => {
+      state.status = action.payload?.status;
+      state.statusText = action.payload?.statusText ?? "Success";
+    },
+    logoutError: (state, action) => {
+      state.status = action.payload?.status ?? 500;
+      state.statusText = action.payload?.statusText ?? "Network Error";
+    },
+  },
+});
+
+export const userActions = userSlice.actions;
+export default userSlice.reducer;

--- a/src/features/user/userSlice.tsx
+++ b/src/features/user/userSlice.tsx
@@ -9,7 +9,7 @@ export interface UserState {
 
 const initialState: UserState = {
   circleName: "",
-  isLoggedIn: false,
+  isLoggedIn: true,
   status: 0,
   statusText: "loading",
 };
@@ -21,10 +21,16 @@ export const userSlice = createSlice({
     // login
     login: (state, action) => {},
     loginSuccess: (state, action) => {
-      state.status = action.payload?.status ?? 200;
-      state.statusText = action.payload?.statusText ?? "Success";
-      state.isLoggedIn = true;
-      state.circleName = action.payload.data?.circle;
+      state.status = action.payload?.status;
+      state.statusText = action.payload?.statusText;
+
+      if (action.payload?.status === 500) {
+        console.log("login error : code 500");
+        alert("로그인 실패했습니다.");
+      } else if (action.payload?.status === 200) {
+        state.isLoggedIn = true;
+        state.circleName = action.payload.data?.circle;
+      }
     },
     loginError: (state, action) => {
       state.status = action.payload ?? 500;

--- a/src/features/user/userSlice.tsx
+++ b/src/features/user/userSlice.tsx
@@ -21,11 +21,10 @@ export const userSlice = createSlice({
     // login
     login: (state, action) => {},
     loginSuccess: (state, action) => {
-      console.log(action);
-      state.status = action.payload;
+      state.status = action.payload?.status ?? 200;
       state.statusText = action.payload?.statusText ?? "Success";
       state.isLoggedIn = true;
-      // state.circleName = action.payload.circleName;
+      state.circleName = action.payload.data?.circle;
     },
     loginError: (state, action) => {
       state.status = action.payload ?? 500;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "components/app/App";
-import { store } from "components/app/store";
+import store from "components/app/store";
 import { Provider } from "react-redux";
 import axios from "axios";
+import { persistStore } from "redux-persist";
+import { PersistGate } from "redux-persist/integration/react";
+
+const persistor = persistStore(store);
 
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>,
   document.getElementById("root")

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,20 +3,17 @@ import { useNavigate } from "react-router-dom";
 import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
 import Input from "components/atoms/Input";
-import ErrorMsg from "components/atoms/ErrorMsg";
 import Logo from "components/atoms/Logo";
 import Button from "components/atoms/Button";
-import { useAppDispatch, useAppSelector } from "hooks/redux-hooks";
+import { useAppDispatch } from "hooks/redux-hooks";
 import { userActions } from "features/user/userSlice";
 
 function Login() {
   const navigation = useNavigate();
-  const user = useAppSelector((state) => state.userReducer);
   const dispatch = useAppDispatch();
 
   const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
-  const [error, setError] = useState("");
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const {
@@ -53,11 +50,11 @@ function Login() {
             value={pw}
             onChange={handleInputChange}
           />
-          <ErrorMsg>{error}</ErrorMsg>
           <Button type="submit" className="signin auth-btn">
             LOGIN
           </Button>
         </form>
+
         <Button
           className="regist auth-btn"
           onClick={() => navigation("/regist")}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,12 +6,15 @@ import Input from "components/atoms/Input";
 import ErrorMsg from "components/atoms/ErrorMsg";
 import Logo from "components/atoms/Logo";
 import Button from "components/atoms/Button";
-import { onLogin } from "api/auth";
+import { useAppDispatch, useAppSelector } from "hooks/redux-hooks";
+import { userActions } from "features/user/userSlice";
 
 function Login() {
   const navigation = useNavigate();
+  const user = useAppSelector((state) => state.userReducer);
+  const dispatch = useAppDispatch();
 
-  const [id, setId] = useState("");
+  const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
   const [error, setError] = useState("");
 
@@ -20,14 +23,13 @@ function Login() {
       target: { name, value },
     } = e;
 
-    if (name === "id") setId(value);
+    if (name === "email") setEmail(value);
     else if (name === "pw") setPw(value);
   };
 
   const handleLoginClick = (e: FormEvent) => {
     e.preventDefault();
-
-    onLogin(id, pw);
+    dispatch(userActions.login({ email, pw }));
   };
 
   return (
@@ -37,10 +39,10 @@ function Login() {
 
         <form onSubmit={handleLoginClick}>
           <Input
-            placeholder="아이디를 입력해주세요"
+            placeholder="이메일을 입력해주세요"
             className="auth-input"
-            name="id"
-            value={id}
+            name="email"
+            value={email}
             onChange={handleInputChange}
           />
           <Input

--- a/src/pages/Regist.tsx
+++ b/src/pages/Regist.tsx
@@ -27,7 +27,6 @@ function Regist() {
     setErrorMsg("error");
   };
 
-  // TODO : Auth useEffect
   useEffect(() => {
     console.log("regist page mount");
     return () => {
@@ -73,7 +72,7 @@ function Regist() {
             onChange={handleInputChange}
           />
           <ErrorMsg>{errorMsg}</ErrorMsg>
-          <Button type="submit" className="regist">
+          <Button type="submit" className="regist auth-btn">
             회원가입
           </Button>
         </form>

--- a/src/types/authType.tsx
+++ b/src/types/authType.tsx
@@ -1,0 +1,5 @@
+export interface LoginInputData {
+  email: string;
+  pw: string;
+  circleName?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,7 +1015,7 @@
     "core-js-pure" "^3.20.2"
     "regenerator-runtime" "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   "integrity" "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw=="
   "resolved" "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz"
   "version" "7.17.2"
@@ -1618,6 +1618,50 @@
   "resolved" "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz"
   "version" "2.11.2"
 
+"@redux-saga/core@^1.1.3":
+  "integrity" "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz"
+  "version" "1.1.3"
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@redux-saga/deferred" "^1.1.2"
+    "@redux-saga/delay-p" "^1.1.2"
+    "@redux-saga/is" "^1.1.2"
+    "@redux-saga/symbols" "^1.1.2"
+    "@redux-saga/types" "^1.1.0"
+    "redux" "^4.0.4"
+    "typescript-tuple" "^2.2.1"
+
+"@redux-saga/deferred@^1.1.2":
+  "integrity" "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz"
+  "version" "1.1.2"
+
+"@redux-saga/delay-p@^1.1.2":
+  "integrity" "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "@redux-saga/symbols" "^1.1.2"
+
+"@redux-saga/is@^1.1.2":
+  "integrity" "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "@redux-saga/symbols" "^1.1.2"
+    "@redux-saga/types" "^1.1.0"
+
+"@redux-saga/symbols@^1.1.2":
+  "integrity" "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz"
+  "version" "1.1.2"
+
+"@redux-saga/types@^1.1.0":
+  "integrity" "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+  "resolved" "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz"
+  "version" "1.1.0"
+
 "@reduxjs/toolkit@1.7.1":
   "integrity" "sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q=="
   "resolved" "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.1.tgz"
@@ -2138,6 +2182,13 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     "csstype" "^3.0.2"
+
+"@types/redux-logger@3.0.9":
+  "integrity" "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg=="
+  "resolved" "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz"
+  "version" "3.0.9"
+  dependencies:
+    "redux" "^4.0.0"
 
 "@types/resolve@1.17.1":
   "integrity" "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw=="
@@ -3788,6 +3839,11 @@
   "integrity" "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
   "resolved" "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
   "version" "0.7.0"
+
+"deep-diff@^0.3.5":
+  "integrity" "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+  "resolved" "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz"
+  "version" "0.3.8"
 
 "deep-equal@^1.0.1":
   "integrity" "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g=="
@@ -7902,12 +7958,31 @@
     "indent-string" "^4.0.0"
     "strip-indent" "^3.0.0"
 
+"redux-logger@3.0.6":
+  "integrity" "sha1-91VZZvMJjzyIYExEnPC69XeCdL8="
+  "resolved" "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz"
+  "version" "3.0.6"
+  dependencies:
+    "deep-diff" "^0.3.5"
+
+"redux-persist@6.0.0":
+  "integrity" "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
+  "resolved" "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz"
+  "version" "6.0.0"
+
+"redux-saga@1.1.3":
+  "integrity" "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw=="
+  "resolved" "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz"
+  "version" "1.1.3"
+  dependencies:
+    "@redux-saga/core" "^1.1.3"
+
 "redux-thunk@^2.4.1":
   "integrity" "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
   "resolved" "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz"
   "version" "2.4.1"
 
-"redux@^4", "redux@^4.0.0", "redux@^4.1.2", "redux@4.1.2":
+"redux@^4", "redux@^4.0.0", "redux@^4.0.4", "redux@^4.1.2", "redux@>4.0.0", "redux@4.1.2":
   "integrity" "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw=="
   "resolved" "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz"
   "version" "4.1.2"
@@ -9078,6 +9153,25 @@
   "version" "3.1.5"
   dependencies:
     "is-typedarray" "^1.0.0"
+
+"typescript-compare@^0.0.2":
+  "integrity" "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA=="
+  "resolved" "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz"
+  "version" "0.0.2"
+  dependencies:
+    "typescript-logic" "^0.0.0"
+
+"typescript-logic@^0.0.0":
+  "integrity" "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+  "resolved" "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz"
+  "version" "0.0.0"
+
+"typescript-tuple@^2.2.1":
+  "integrity" "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q=="
+  "resolved" "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz"
+  "version" "2.2.1"
+  dependencies:
+    "typescript-compare" "^0.0.2"
 
 "typescript@^3.2.1 || ^4", "typescript@>= 2.7", "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta", "typescript@4.1.6":
   "integrity" "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow=="


### PR DESCRIPTION
📋 Apply redux & redux-saga for authentication

1. react-query 입장에서 auth service 상태들은 서버 상태가 아님. ex) 토큰, user data
2. 그래서 auth는 **redux**로 user 상태를 클라이언트 상태처럼 관리하기로 하였고 (토큰이 만료될 때마다 다시 요청하긴 한다)
3. **redux-saga**로 비즈니스 로직을 처리해주기로 하였다. 
4. 그 이유는 saga 같은 미들웨어가 없으면 View에서 비즈니스 로직을 처리해줘야하는 불상사가 벌어짐 (관심사 분리가 안됨)
5. 나머지 상태들은 서버 상태로서, **react-query**로 관리할 것. ex) 투두리스트, 학사공지 등등


📋 HOC 고차 컴포넌트 적용.
1. Home, Manage, Login, Regist 컴포넌트 모두 isLoggedIn 이라는 변수에 영향을 받음
2. !isLoggedIn 이라면 Home, Manage 는 접근 불가능하고, isLoggedIn일 때는 Login, Regist 접근을 막아야 함.
3. 모든 컴포넌트에서 같은 로직으로 처리를 해줄 수 있지만, 코드 중복이 발생
4. 따라서 HOC 라는 리액트 고차 컴포넌트를 적용하여 코드 중복을 막을 수 있음.

https://ko.reactjs.org/docs/higher-order-components.html